### PR TITLE
Adds #1 (optional command line arguments) in a rather crude way

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <template class="BxtLauncherWindow" parent="GtkApplicationWindow">
@@ -64,6 +64,7 @@
             <property name="receives_default">True</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
+            <property name="margin_bottom">16</property>
             <signal name="clicked" handler="launch_button_clicked_cb" swapped="no"/>
             <style>
               <class name="suggested-action"/>
@@ -73,6 +74,34 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkExpander" id="additional_cmdline_expander">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkEntry" id="additional_cmdline_entry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="margin_top">4</property>
+                <property name="caps_lock_warning">False</property>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Additional command line arguments</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/src/window.vala
+++ b/src/window.vala
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace BxtLauncher {
     [GtkTemplate (ui = "/yalter/BxtLauncher/window.ui")]
     public class Window : Gtk.ApplicationWindow {
@@ -23,6 +24,12 @@ namespace BxtLauncher {
         private string? bxt_path { get; set; }
 
         private Gtk.MessageDialog? dialog { get; set; }
+
+        [GtkChild]
+        private Gtk.Entry additional_cmdline_entry;
+
+        [GtkChild]
+        private Gtk.Expander additional_cmdline_expander;
 
         public Window (Gtk.Application app) {
             Object (application: app);
@@ -234,6 +241,18 @@ namespace BxtLauncher {
 
             string[] spawn_args = {"./hl_linux", "-steam"};
             string[] spawn_env = Environ.get ();
+
+            if (additional_cmdline_expander.expanded) {
+                string additional_cmdline_str = additional_cmdline_entry.text;
+                debug (@"Additional commands line arguments = $(additional_cmdline_str)");
+
+                string[] additional_cmdline = additional_cmdline_str.split(" ");
+                for (int i = 0; i < additional_cmdline.length; i++) {
+                    if (additional_cmdline[i] != "") {
+                        spawn_args += additional_cmdline[i];
+                    }
+                }
+            }
 
             var hl_ld_library_path = settings.get_string ("hl-ld-library-path");
             var hl_ld_preload = settings.get_string ("hl-ld-preload");


### PR DESCRIPTION
Hello. 
First time using Vala.

I've implemented the feature I suggested (#1) in a rather crude way, but then again it shouldn't matter that much since half-life just happily ignores garbage, e.g. stuff like this still loads:

`	working_directory = /home/unko/.local/share/Steam/steamapps/common/Half-Life
	argv = ./hl_linux, -steam, adsadasdasdfa, sdfsd, čt, čštgerg, fdgdf, g
`

The "crude way" consists of adding just a GtkExpander and a GtkEntry for the command line arguments to the window (therefore added another line to the GtkBox) and when the Expander is expanded splitting the GtkEntry value string, iterating over it and adding it to the string array `string[] spawn_args`.

**UI when not expanded:**
![16257](https://user-images.githubusercontent.com/5108747/84316595-ab2e2580-ab6b-11ea-8bc9-f728c8489747.png)

**UI when expanded:**
![858](https://user-images.githubusercontent.com/5108747/84316656-c6993080-ab6b-11ea-941b-9556d4de2378.png)

Still, any suggestions/critique/rework is very welcome. 