### PR TITLE
vala warning fix

### DIFF
--- a/src/window.vala
+++ b/src/window.vala
@@ -25,7 +25,7 @@ namespace BxtLauncher {
         private Gtk.MessageDialog? dialog { get; set; }
 
         [GtkChild]
-        private Gtk.ComboBoxText mod_combo_box;
+        private unowned Gtk.ComboBoxText mod_combo_box;
 
         public Window (Gtk.Application app) {
             Object (application: app);


### PR DESCRIPTION
Fix warning from vala when building

```
➜  bxt-launcher git:(master) ✗ ninja -C build install
ninja: Entering directory `build'
[6/12] Compiling Vala source ../src/main.vala ../src/process.vala ../src/system-monitor.vala ../src/window.vala
../src/window.vala:28.9-28.46: warning: [GtkChild] fields must be declared as `unowned'
   28 |         private Gtk.ComboBoxText mod_combo_box;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
Compilation succeeded - 1 warning(s)
```

As suggested here, GtkChild fields need unowned declaration: https://gitlab.gnome.org/GNOME/vala/-/issues/1121