### PR TITLE
Added all GoldSrc games from Valve and added OpenAG

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -88,6 +88,7 @@
                   <item id="dod">Day of Defeat</item>
                   <item id="dmc">Deathmatch Classic</item>
                   <item id="ricochet">Ricochet</item>
+                  <item id="ag">OpenAG</item>
                 </items>
               </object>
               <packing>

--- a/src/window.ui
+++ b/src/window.ui
@@ -79,8 +79,15 @@
                 <property name="active_id">valve</property>
                 <items>
                   <item id="valve">Half-Life</item>
-                  <item id="gearbox" translatable="yes">Opposing Force</item>
-                  <item id="bshift" translatable="yes">Blue Shift</item>
+                  <item id="gearbox">Opposing Force</item>
+                  <item id="bshift">Blue Shift</item>
+                  <item id="cstrike">Counter-Strike</item>
+                  <item id="czero">Counter-Strike Condition Zero</item>
+                  <item id="czeror">Counter-Strike Condition Zero Deleted Scenes</item>
+                  <item id="tfc">Team Fortress Classic</item>
+                  <item id="dod">Day of Defeat</item>
+                  <item id="dmc">Deathmatch Classic</item>
+                  <item id="ricochet">Ricochet</item>
                 </items>
               </object>
               <packing>

--- a/src/window.ui
+++ b/src/window.ui
@@ -82,8 +82,8 @@
                   <item id="gearbox">Opposing Force</item>
                   <item id="bshift">Blue Shift</item>
                   <item id="cstrike">Counter-Strike</item>
-                  <item id="czero">Counter-Strike Condition Zero</item>
-                  <item id="czeror">Counter-Strike Condition Zero Deleted Scenes</item>
+                  <item id="czero">Counter-Strike: Condition Zero</item>
+                  <item id="czeror">Counter-Strike: Condition Zero Deleted Scenes</item>
                   <item id="tfc">Team Fortress Classic</item>
                   <item id="dod">Day of Defeat</item>
                   <item id="dmc">Deathmatch Classic</item>

--- a/src/window.vala
+++ b/src/window.vala
@@ -100,6 +100,13 @@ namespace BxtLauncher {
                 mod_combo_box.append ("valve", "Half-Life");
                 mod_combo_box.append ("gearbox", "Opposing Force");
                 mod_combo_box.append ("bshift", "Blue Shift");
+                mod_combo_box.append ("cstrike", "Counter-Strike");
+                mod_combo_box.append ("czero", "Counter-Strike Condition Zero");
+                mod_combo_box.append ("czeror", "Counter-Strike Condition Zero Deleted Scenes");
+                mod_combo_box.append ("tfc", "Team Fortress Classic");
+                mod_combo_box.append ("dod", "Day of Defeat");
+                mod_combo_box.append ("dmc", "Deathmatch Classic");
+                mod_combo_box.append ("ricochet", "Ricochet");
                 mod_combo_box.set_active_id ("valve");
             } else {
                 string? first = null;

--- a/src/window.vala
+++ b/src/window.vala
@@ -101,8 +101,8 @@ namespace BxtLauncher {
                 mod_combo_box.append ("gearbox", "Opposing Force");
                 mod_combo_box.append ("bshift", "Blue Shift");
                 mod_combo_box.append ("cstrike", "Counter-Strike");
-                mod_combo_box.append ("czero", "Counter-Strike Condition Zero");
-                mod_combo_box.append ("czeror", "Counter-Strike Condition Zero Deleted Scenes");
+                mod_combo_box.append ("czero", "Counter-Strike: Condition Zero");
+                mod_combo_box.append ("czeror", "Counter-Strike: Condition Zero Deleted Scenes");
                 mod_combo_box.append ("tfc", "Team Fortress Classic");
                 mod_combo_box.append ("dod", "Day of Defeat");
                 mod_combo_box.append ("dmc", "Deathmatch Classic");

--- a/src/window.vala
+++ b/src/window.vala
@@ -107,6 +107,7 @@ namespace BxtLauncher {
                 mod_combo_box.append ("dod", "Day of Defeat");
                 mod_combo_box.append ("dmc", "Deathmatch Classic");
                 mod_combo_box.append ("ricochet", "Ricochet");
+                mod_combo_box.append ("ag", "OpenAG");
                 mod_combo_box.set_active_id ("valve");
             } else {
                 string? first = null;


### PR DESCRIPTION
It is really convenient to test changes for BXT in different games without changing the `-game` option each time by using such a GUI launcher

I know some of these games are made for multiplayer, but BXT can be used often for TAS purposes or watching demos with custom HUDs enabled as `bxt_hud_origin`, so it really makes sense to add them to the list